### PR TITLE
Update depends of sparky-desktop-xfce

### DIFF
--- a/sparky-desktop-xfce/DEBIAN/control
+++ b/sparky-desktop-xfce/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 20201115
 Architecture: all
 Maintainer: pavroo <pavroo@onet.eu>
 Installed-Size: 32
-Depends: gpicview, lightdm, menu, menu-xdg, mousepad, network-manager, network-manager-gnome, pavucontrol, plymouth, policykit-1-gnome, pulseaudio, smbclient, sparky-about, sparky-aptus-upgrade, sparky-core, sparky-aptus-appcenter | sparky-aptus, sparky-plymouth, sudo, synaptic, system-config-printer, thunar, thunar-archive-plugin, xfce4, xfce4-datetime-plugin, xfce4-notifyd, xfce4-power-manager, xfce4-screenshooter, xfce4-taskmanager, xfce4-terminal, xfce4-whiskermenu-plugin, xfce4-xkb-plugin, xfwm4-themes, xarchiver|file-roller, xscreensaver, xdg-utils, xdg-user-dirs, xinit
+Depends: gpicview | ristretto, lightdm, menu, menu-xdg, mousepad, network-manager, network-manager-gnome, pavucontrol, plymouth, policykit-1-gnome, pulseaudio, smbclient, sparky-about, sparky-aptus-upgrade, sparky-core, sparky-aptus-appcenter | sparky-aptus, sparky-plymouth, sudo, synaptic, system-config-printer, thunar, thunar-archive-plugin, xfce4, xfce4-datetime-plugin, xfce4-notifyd, xfce4-power-manager, xfce4-screenshooter, xfce4-taskmanager, xfce4-terminal, xfce4-whiskermenu-plugin, xfce4-xkb-plugin, xfwm4-themes, xarchiver|file-roller, xscreensaver, xdg-utils, xdg-user-dirs, xinit
 Recommends: sparky6-theme
 Suggests: menu-l10n, gufw, ufw, gdebi | debi-tool
 Homepage: https://sparkylinux.org


### PR DESCRIPTION
`gpicview` -> `gpicview` | `ristretto`
Allow `sparky-desktop` not has to install `gpicview` while installing `sparky-desktop-xfce`.
* * *
Ristretto is the official image viewer of Xfce, it is more functional than GPicView.
* https://packages.debian.org/bullseye/ristretto
* https://docs.xfce.org/apps/ristretto/start